### PR TITLE
fix: expense category 'accommodation' displays raw key

### DIFF
--- a/app/expenses/[id].tsx
+++ b/app/expenses/[id].tsx
@@ -18,7 +18,7 @@ import { useTranslation } from "../../hooks/useTranslation";
 
 const CATEGORIES = [
   { id: "transport", icon: "train" },
-  { id: "accommodation", icon: "hotel" },
+  { id: "hotel", icon: "hotel" },
   { id: "fuel", icon: "gas-pump" },
   { id: "parking", icon: "parking" },
   { id: "meals", icon: "utensils" },

--- a/app/expenses/create.tsx
+++ b/app/expenses/create.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from "../../hooks/useTranslation";
 
 const CATEGORIES = [
   { id: "transport", icon: "train" },
-  { id: "accommodation", icon: "hotel" },
+  { id: "hotel", icon: "hotel" },
   { id: "fuel", icon: "gas-pump" },
   { id: "parking", icon: "parking" },
   { id: "meals", icon: "utensils" },


### PR DESCRIPTION
## Bug

In the Add Expense screen, the category **Accommodation** was displaying `cat_accomodation` (the raw i18n key) instead of the translated label.

## Root cause

The category array used `id: "accommodation"` but the translation keys are named `cat_hotel`. The `t('cat_accommodation')` lookup failed silently and returned the key itself.

## Fix

Changed the category ID from `"accommodation"` to `"hotel"` in:
- `app/expenses/create.tsx`
- `app/expenses/[id].tsx`

This aligns with the existing `cat_hotel` translation key (EN: "Hotel", JA: "宿泊費").