### PR TITLE
fix(ui): prevent hero card from showing past activities (Issue #29)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -101,7 +101,7 @@ export default function HomeScreen() {
     // Add Schedule Items
     if (schedule) {
       schedule.forEach(s => {
-        let itemDate = parseLocalDate(s.date);
+        const itemDate = parseLocalDate(s.date);
         // Include items from today onwards
         if (itemDate >= today) {
              candidates.push({

--- a/context/TravelContext.tsx
+++ b/context/TravelContext.tsx
@@ -1,7 +1,7 @@
-import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../lib/supabase';
-import { Project, LogisticsTicket, Accommodation } from '../types';
+import { LogisticsTicket, Accommodation } from '../types';
 import { parseLocalDate } from '../lib/utils';
 
 export interface TripDetails {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -47,9 +47,19 @@ export const decode = (base64: string): ArrayBuffer => {
 /**
  * Parses a YYYY-MM-DD string into a Date object at local midnight.
  * Avoids the UTC-shift bug when using new Date('YYYY-MM-DD').
+ * Throws an error if the input is not a valid YYYY-MM-DD string.
  */
 export const parseLocalDate = (dateStr: string): Date => {
+  if (typeof dateStr !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    throw new Error(`parseLocalDate: expected 'YYYY-MM-DD' string, got '${dateStr}'`);
+  }
   const [year, month, day] = dateStr.split('-').map(Number);
-  return new Date(year, month - 1, day);
+  const date = new Date(year, month - 1, day);
+  
+  // Final validation to catch cases like 2026-02-31 (which JS converts to March)
+  if (isNaN(date.getTime()) || date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    throw new Error(`parseLocalDate: invalid calendar date '${dateStr}'`);
+  }
+  
+  return date;
 };
-


### PR DESCRIPTION
This PR fixes the logic in the HomeScreen hero card to ensure past projects and trips are not displayed as 'Next Activity'.

Key changes:
- Extended TravelContext to fetch and expose start_date/end_date for projects.
- Updated TravelContext auto-selection to prefer the first active/future project.
- Fixed a bug in HomeScreen where Date mutation was causing incorrect comparisons.
- Added an end-date check to the trip fallback in the nextActivity calculation.